### PR TITLE
fix: Add support when start and end of the date range are the same

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "moment-date-range",
+	"name": "@simonja/moment-date-range",
 	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/source/index.ts
+++ b/source/index.ts
@@ -23,11 +23,11 @@ function isValidRange(step: number, start: Moment, end: Moment | undefined): [bo
 	}
 
 	if (step > 0) {
-		return [start.isBefore(end), '`start` needs to be before `end`'];
+		return [start.isSameOrBefore(end), '`start` needs to be before `end`'];
 	}
 
 	if (step < 0) {
-		return [start.isAfter(end), '`start` needs to be after `end`'];
+		return [start.isSameOrAfter(end), '`start` needs to be after `end`'];
 	}
 
 	return [false, 'Unknown condition'];

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -62,6 +62,22 @@ test('should iterate in a specific range', t => {
 	]);
 });
 
+test('should iterate if start and end are the same', t => {
+	const iterator = range(moment('2020-01-01'), moment('2020-01-01'));
+
+	const dates = Array.from<Moment>(iterator).map<string>(item => item.format('YYYY-MM-DD'));
+
+	t.deepEqual(dates, ['2020-01-01']);
+});
+
+test('should iterate if start and end are the same and step is negative', t => {
+	const iterator = range(moment('2020-01-01'), moment('2020-01-01'), {step: -1});
+
+	const dates = Array.from<Moment>(iterator).map<string>(item => item.format('YYYY-MM-DD'));
+
+	t.deepEqual(dates, ['2020-01-01']);
+});
+
 test('should iterate backwards', t => {
 	const iterator = range(moment('2020-01-31'), {step: -1});
 


### PR DESCRIPTION
As we discussed, when the start and end dates are the same, it should not fail.